### PR TITLE
Rename to network

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,19 +8,19 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Neuton:ital,wght@0,200;0,300;0,400;0,700;0,800;1,400&family=Manrope:wght@200;300;400;500;600;700;800&display=swap">
   <link rel= "stylesheet" href= "https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css" >
   <link rel="stylesheet" href="styles/style.css">
-  
-  <title>Prague Programming Languages and Systems Research Group - PRG &#x2022; PRG</title>
+
+  <title>Prague Programming Languages and Systems Research Network - PRG &#x2022; PRG</title>
   <meta name="description" content="We are a group of researchers based in Prague interested in programming languages and systems."/>
   <link rel="canonical" href="https://prgprg.org" />
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="Prague Programming Languages and Systems Research Group - PRG &#x2022; PRG" />
+  <meta property="og:title" content="Prague Programming Languages and Systems Research Network - PRG &#x2022; PRG" />
   <meta property="og:description" content="We are a group of researchers based in Prague interested in programming languages and systems." />
   <meta property="og:url" content="https://prgprg.org" />
   <meta property="og:site_name" content="PRG &#x2022; PRG" />
   <meta property="og:image" content="https://prgprg.org/img/card.png" />
   <meta property="og:image:alt" content="Prague Cityscape" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Prague Programming Languages and Systems Research Group - PRG &#x2022; PRG" />
+  <meta name="twitter:title" content="Prague Programming Languages and Systems Research Network - PRG &#x2022; PRG" />
   <meta name="twitter:description" content="We are a group of researchers based in Prague interested in programming languages and systems." />
   <meta name="twitter:image" content="https://prgprg.org/img/card.png" />
 </head>
@@ -30,7 +30,7 @@
     <div class="container"><div class="row"><div class="col-12">
       <div class="bot">
         <h1>PRG &#x2022; PRG</h1>
-        <h2>Prague Programming Languages and Systems Research Group</h2>
+        <h2>Prague Programming Languages and Systems Research Network</h2>
       </div>
     </div></div></div>
   </div>
@@ -40,4 +40,3 @@
   </article>
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -7,20 +7,20 @@ layout: default
   <div class="col-9-md">
     <p>
       We are a group of researchers based in Prague interested in programming languages and systems
-      from the <a href="https://prl-prg.github.io/">Programming Research Laboratory</a> at the 
-      Czech Technical University and the <a href="https://d3s.mff.cuni.cz/">Department of Distributed 
-      and Dependable Systems</a> at the Faculty of Mathematics and Physics, Charles University. We meet regularly, organise joint events 
-      and promote programming languages and systems research, projects and courses in Prague. 
+      from the <a href="https://prl-prg.github.io/">Programming Research Laboratory</a> at the
+      Czech Technical University and the <a href="https://d3s.mff.cuni.cz/">Department of Distributed
+      and Dependable Systems</a> at the Faculty of Mathematics and Physics, Charles University. We meet regularly, organise joint events
+      and promote programming languages and systems research, projects and courses in Prague.
     </p>
     <p>
-      If you are interested in joining our group, drop us an email or come to any of the events
+      If you are interested in joining our network, drop us an email or come to any of the events
       listed below!
     </p>
   </div>
 </div><div class="row">
   <div class="col-9-md">
     <h2>Regular Events</h2>
-    <p>We run a number of events at both Czech Technical University and Charles University where we can meet 
+    <p>We run a number of events at both Czech Technical University and Charles University where we can meet
       and talk about programming languages and systems. To make talking to each other easier, our reading group
       alternates between the two locations!</p>
   </div>
@@ -33,7 +33,7 @@ layout: default
       <li><a href="https://github.com/prgprg-org/reading-group">List of past and upcoming meetings</a></li>
     </ul>
     <p>
-      Regular reading group where we discuss papers of interest to the group. 
+      Regular reading group where we discuss papers of interest to the group.
       Topics range from essential PL reading to recent papers of interest.
       All students are welcome to join and suggest papers!</p>
   </div>
@@ -45,8 +45,8 @@ layout: default
       <li>Come and loook for us or email Tomas to check</li>
     </ul>
     <p>
-      We meet at 12:00 in front of S204 to talk about current research ideas, open 
-      problems and whatever interests us and then have lunch together at 
+      We meet at 12:00 in front of S204 to talk about current research ideas, open
+      problems and whatever interests us and then have lunch together at
       the nearby <a href="https://www.hamu.cz/en/about-hamu/university-cafe/">Café HAMU</a> around 13:00.</p>
   </div>
 </div><div class="row events">
@@ -77,7 +77,7 @@ layout: default
 <div class="row">
   <div class="col-9-md">
     <h2>Work with Us!</h2>
-    <p>We have a range of projects and thesis topics for students at both CTU and MFF. 
+    <p>We have a range of projects and thesis topics for students at both CTU and MFF.
       We also often have funding for PhD students and post-doctoral researchers, or can help you with various applications.
       If you want to move to Prague permanently, we can also give you various tips!
     </p>


### PR DESCRIPTION
The word "group" seems to have some unfortunate connotations at our institution, so I renamed this to "network", which seems more innocent.